### PR TITLE
Update ESLint configuration for React properties

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "react/no-unknown-property": "off"
+  }
 }


### PR DESCRIPTION
Disable the unknown property rule in ESLint for React to allow for more flexibility in component properties.